### PR TITLE
commands: allow sub-commands

### DIFF
--- a/.github/workflows/assess.yml
+++ b/.github/workflows/assess.yml
@@ -1,0 +1,24 @@
+name: Run on Linux
+
+on:
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  Linux:
+
+    runs-on: ubuntu-22.04
+
+    steps:
+    - name: Install Packages
+      run: sudo apt-get install make python3-setuptools sudo zlib1g-dev
+
+    - uses: actions/checkout@v1
+
+    - name: get python modules
+      run: python3 -m pip install --upgrade --user -U -r requirements.txt
+
+    - name: Run script in assess mode
+      run: |
+          ./SpecSAT.py --debug assess

--- a/.github/workflows/assess.yml
+++ b/.github/workflows/assess.yml
@@ -1,4 +1,4 @@
-name: Run on Linux
+name: Run Assessing Environment on Linux
 
 on:
   pull_request:
@@ -6,7 +6,7 @@ on:
       - '**'
 
 jobs:
-  Linux:
+  Linux-docker:
 
     runs-on: ubuntu-22.04
 
@@ -22,3 +22,19 @@ jobs:
     - name: Run script in assess mode
       run: |
           ./SpecSAT.py --debug assess
+
+  Linux-no-docker:
+
+    runs-on: ubuntu-22.04
+
+    steps:
+    - name: Install Packages
+      run: sudo apt-get install make python3-setuptools sudo zlib1g-dev
+
+    - uses: actions/checkout@v1
+
+    - name: get python modules
+      run: python3 -m pip install --upgrade --user -U -r requirements.txt
+    - name: Run script in assess mode without docker
+      run: |
+          ./SpecSAT.py --debug assess -u

--- a/.github/workflows/assess.yml
+++ b/.github/workflows/assess.yml
@@ -21,7 +21,7 @@ jobs:
 
     - name: Run script in assess mode
       run: |
-          ./SpecSAT.py --debug assess
+          ./SpecSAT.py assess
 
   Linux-no-docker:
 
@@ -37,4 +37,21 @@ jobs:
       run: python3 -m pip install --upgrade --user -U -r requirements.txt
     - name: Run script in assess mode without docker
       run: |
-          ./SpecSAT.py --debug assess -u
+          ./SpecSAT.py assess -u
+
+
+  Linux-no-docker-kissat:
+
+    runs-on: ubuntu-22.04
+
+    steps:
+    - name: Install Packages
+      run: sudo apt-get install make python3-setuptools sudo zlib1g-dev
+
+    - uses: actions/checkout@v1
+
+    - name: get python modules
+      run: python3 -m pip install --upgrade --user -U -r requirements.txt
+    - name: Run script in assess mode without docker, only using Kissat
+      run: |
+          ./SpecSAT.py assess -u -C -M

--- a/.github/workflows/assess.yml
+++ b/.github/workflows/assess.yml
@@ -23,6 +23,10 @@ jobs:
       run: |
           ./SpecSAT.py assess -u -o assess.json
 
+    - name: Show results
+      run: |
+          cat assess.json
+
     - name: 'Upload Artifact'
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/assess.yml
+++ b/.github/workflows/assess.yml
@@ -6,22 +6,6 @@ on:
       - '**'
 
 jobs:
-  Linux-docker:
-
-    runs-on: ubuntu-22.04
-
-    steps:
-    - name: Install Packages
-      run: sudo apt-get install make python3-setuptools sudo zlib1g-dev
-
-    - uses: actions/checkout@v1
-
-    - name: get python modules
-      run: python3 -m pip install --upgrade --user -U -r requirements.txt
-
-    - name: Run script in assess mode
-      run: |
-          ./SpecSAT.py assess
 
   Linux-no-docker:
 
@@ -37,8 +21,14 @@ jobs:
       run: python3 -m pip install --upgrade --user -U -r requirements.txt
     - name: Run script in assess mode without docker
       run: |
-          ./SpecSAT.py assess -u
+          ./SpecSAT.py assess -u -o assess.json
 
+    - name: 'Upload Artifact'
+      uses: actions/upload-artifact@v3
+      with:
+        name: assess.json
+        path: assess.json
+        retention-days: 5
 
   Linux-no-docker-kissat:
 

--- a/.github/workflows/linux-bash.yml
+++ b/.github/workflows/linux-bash.yml
@@ -17,5 +17,5 @@ jobs:
     - uses: actions/checkout@v1
 
     - name: Run CI script
-      run: ./SpecSAT.sh -d -u -A ""
+      run: ./SpecSAT.sh -d specsat -u -A ""
 

--- a/.github/workflows/linux-input-output.yml
+++ b/.github/workflows/linux-input-output.yml
@@ -21,5 +21,5 @@ jobs:
 
     - name: run script first writing CNFs to disk, and next consume them
       run: |
-          ./SpecSAT.py -l -d -u -D tmp
-          ./SpecSAT.py -l -d -u -I tmp
+          ./SpecSAT.py -d specsat -l -u -D tmp
+          ./SpecSAT.py -d specsat -l -u -I tmp

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -20,11 +20,11 @@ jobs:
       run: python3 -m pip install --upgrade --user -U -r requirements.txt
 
     - name: run CI script
-      run: ./SpecSAT.py -d -u
+      run: ./SpecSAT.py -d specsat -u
 
     - name: run script in light mode, and dumping everything to a single archive
       run: |
-          ./SpecSAT.py -l -u -Z dump.tar.xz
+          ./SpecSAT.py specsat -l -u -Z dump.tar.xz
           tar -tJf dump.tar.xz &> /dev/null
           ls -l dump.tar.xz
 
@@ -42,11 +42,11 @@ jobs:
       run: python3 -m pip install --upgrade --user -U -r requirements.txt
 
     - name: run CI script
-      run: ./SpecSAT.py -d -u
+      run: ./SpecSAT.py -d specsat -u
 
     - name: run script in light mode, and dumping everything to a single archive
       run: |
-          ./SpecSAT.py -l -u -Z dump.tar.xz
+          ./SpecSAT.py specsat -l -u -Z dump.tar.xz
           tar -tJf dump.tar.xz &> /dev/null
           ls -l dump.tar.xz
 
@@ -64,10 +64,10 @@ jobs:
       run: python3 -m pip install --upgrade --user -U -r requirements.txt
 
     - name: run CI script
-      run: ./SpecSAT.py -d -u
+      run: ./SpecSAT.py -d specsat -u
 
     - name: run script in light mode, and dumping everything to a single archive
       run: |
-          ./SpecSAT.py -l -u -Z dump.tar.xz
+          ./SpecSAT.py specsat -l -u -Z dump.tar.xz
           tar -tJf dump.tar.xz &> /dev/null
           ls -l dump.tar.xz

--- a/README.md
+++ b/README.md
@@ -274,3 +274,17 @@ Full command to create relevant output for investigation:
 ```
 ./SpecSAT.sh -d specsat -A "" -i 3 -Z archive.tar.xz
 ```
+
+## Assessing Environment
+
+Some SAT solvers behave differently on different platforms. To be able to check
+how solvers behave, the 'assess' command helps identifying these issues, by
+checking the number of conflicts used for the same CNF, and statically linking
+the SAT solvers, building them in a docker container, to ensure a stable
+environment.
+
+The following command allows to generate such a report for the given platform:
+
+```
+./SpecSAT.py assess -o assess.json
+```

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ automatically be written into the 'archive' directory. Finally, the generated
 report, as well as all solver output, will be added to an archive tar file.
 
 ```
-./SpecSAT.sh -A "" -i 3 -Z archive.tar.xz
+./SpecSAT.sh specsat -A "" -i 3 -Z archive.tar.xz
 ```
 
 A more complex example, to use more capabilities of the used SAT solver and to
@@ -40,6 +40,7 @@ and stores the report in the specified file:
 
 ```
     ./SpecSAT.py -d \
+        specsat \ 
         --sat-measure-extra-env=GLIBC_TUNABLES=glibc.malloc.hugetlb=1 \
         --sat-use-solver-docker -u \
         -H \
@@ -62,7 +63,7 @@ The measured data can be strored to report files, where also a full report with
 the native results can be stored:
 
 ```
-./SpecSAT.py -r full-report.json -o output.json
+./SpecSAT.py specsat -r full-report.json -o output.json
 ```
 
 ### Running with no docker available
@@ -80,7 +81,7 @@ First, run a lite run, and build the SAT solver in a docker container. Also,
 store the solver in an archive.
 
 ```
-./SpecSAT.py -l -z mergesat.tar.xz -o precompile-report.json
+./SpecSAT.py specsat -l -z mergesat.tar.xz -o precompile-report.json
 ```
 
 #### Run actual measurement with pre-compiled solver
@@ -90,7 +91,7 @@ then forward it to SpecSAT.
 
 ```
 tar xJf mergesat.tar.xz
-./SpecSAT.sh -r full-report.json -o output.json --solver-location mergesat
+./SpecSAT.sh specsat -r full-report.json -o output.json --solver-location mergesat
 ```
 
 Note: the new tool will now complain about using an external solver, and
@@ -124,14 +125,14 @@ environment (via venv). Furthermore, the wrapper supports two command line
 parameters:
 
 ```
-    <some_path>/SpecSAT.sh --run-from-install [args]
+    <some_path>/SpecSAT.sh specsat --run-from-install [args]
 ```
 
 ... will run SpecSAT.py with args `args` in the directory where the tool itself
 is located. This allows to use the tool in e.g. a distributed environment.
 
 ```
-    <some_path>/SpecSAT.sh --force-install [args]
+    <some_path>/SpecSAT.sh specsat --force-install [args]
 ```
 
 ... will run the wrapper, and re-install the python dependencies. This command
@@ -240,7 +241,7 @@ Note: the report is supposed to not contain any personal data. However, before
       making your data public, make sure you checked the details!
 
  0. clone the repository locally
- 1. run the tool, and generate an auto-report, by running `./SpecSAT.sh -A "" -i 3`
+ 1. run the tool, and generate an auto-report, by running `./SpecSAT.sh specsat -A "" -i 3`
  2. create a git branch in your local repository (e.g. `git checkout -b ...`)
  3. add the new report file to the branch
  4. create a pull request in the main repository with your change
@@ -266,10 +267,10 @@ this archive to the github issue.
 
 Submit an issue here: https://github.com/conp-solutions/SpecSAT/issues
 
-Use these parameters to enable debugging and create an archive: `-d -Z specsat.tar.xz`
+Use these parameters to enable debugging and create an archive: `-d specsat -Z specsat.tar.xz`
 
 Full command to create relevant output for investigation:
 
 ```
-./SpecSAT.sh -A "" -d -i 3 -Z archive.tar.xz
+./SpecSAT.sh -d specsat -A "" -i 3 -Z archive.tar.xz
 ```

--- a/SpecSAT.py
+++ b/SpecSAT.py
@@ -1541,6 +1541,7 @@ def run_assess_environment(args):
 
     max_benchmarks = args.get("max_benchmarks", -1)
     output_file = args.get("output")
+    return_code = 0
 
     if max_benchmarks != -1:
         log.info("Run on the first %d benchmarks", max_benchmarks)
@@ -1681,6 +1682,7 @@ def run_assess_environment(args):
 
     except Exception as e:
         log.exception("Stopped call with exception: %r", e)
+        return_code = 1
     log.info("Full report: %s", json.dumps(assess_report, indent=2))
 
     if output_file:
@@ -1688,7 +1690,7 @@ def run_assess_environment(args):
         with open(output_file, "w") as f:
             json.dump(assess_report, f, indent=4, sort_keys=True)
 
-    return 0
+    return return_code
 
 
 def run_specsat(args):

--- a/SpecSAT.py
+++ b/SpecSAT.py
@@ -971,6 +971,34 @@ def parse_args():
         "-d", "--debug", default=False, action="store_true", help="Log debug output"
     )
     parser.add_argument(
+        "-v",
+        "--version",
+        default=False,
+        action="store_true",
+        help="Print version of the tool",
+    )
+
+    sub_parsers = parser.add_subparsers(help="sub-command help")
+    parser_add_specsat_args(sub_parsers)
+    parser_add_assess_args(sub_parsers)
+
+    args = parser.parse_args()
+    return vars(args)
+
+
+def parser_add_assess_args(sub_parsers):
+    parser = sub_parsers.add_parser(
+        "assess", help="Assess solvers in current environment wrt being stable"
+    )
+    parser.set_defaults(func=run_assess_environment)
+
+
+def parser_add_specsat_args(sub_parsers):
+
+    parser = sub_parsers.add_parser("specsat", help="Benchmark current environment")
+    parser.set_defaults(func=run_specsat)
+
+    parser.add_argument(
         "-A",
         "--auto-archive-report",
         default=None,
@@ -1037,13 +1065,6 @@ def parse_args():
         "--report",
         default=None,
         help="Write full report to this file, including raw data per benchmark.",
-    )
-    parser.add_argument(
-        "-v",
-        "--version",
-        default=False,
-        action="store_true",
-        help="Print version of the tool",
     )
     parser.add_argument(
         "--verbosity", default=0, type=int, help="Set the verbosity level"
@@ -1116,9 +1137,6 @@ def parse_args():
         type=str,
         help="Location of SAT solver to be used",
     )
-
-    args = parser.parse_args()
-    return vars(args)
 
 
 def write_report(report, args, tarxzdump):
@@ -1332,6 +1350,22 @@ def main():
     if args.get("version"):
         print("Version: {}".format(VERSION))
         return 0
+
+    log.debug("args: %r", args)
+
+    function = args["func"]
+    ret = function(args)
+    log.info("Finished command with %d", ret)
+
+
+def run_assess_environment(args):
+    print("Run assessing environment with args %r", args)
+
+    raise NotImplementedError("Assessing environment not available")
+
+
+def run_specsat(args):
+    log.info("Run run_specsat, with args %r", args)
 
     if args.get("docker_host_network"):
         log.debug("Using host network for docker")

--- a/SpecSAT.py
+++ b/SpecSAT.py
@@ -1555,7 +1555,7 @@ def run_assess_environment(args):
                         preexec_fn=set_5m_timeout,
                     )
 
-                    stdout, _ = process.stdout.decode()
+                    stdout = process.stdout.decode()
                     log.debug(
                         "Call output %s with return code %d", stdout, process.returncode
                     )
@@ -1565,6 +1565,9 @@ def run_assess_environment(args):
                         "conflicts": conflicts,
                         "exit_code": process.returncode,
                     }
+                # Cleanup this iteration
+                os.remove(zipped_cnf)
+
     except Exception as e:
         log.exception("Stopped call with exception: %r", e)
     log.info("Full report: %s", json.dumps(assess_report, indent=2))

--- a/SpecSAT.py
+++ b/SpecSAT.py
@@ -1030,6 +1030,27 @@ def parser_add_assess_args(sub_parsers):
         action="store_true",
         help="Disable jailing with docker (more accuracy, native execution)",
     )
+    parser.add_argument(
+        "-C",
+        "--no-cadical",
+        default=False,
+        action="store_true",
+        help="Do not use CaDiCaL solver",
+    )
+    parser.add_argument(
+        "-K",
+        "--no-kissat",
+        default=False,
+        action="store_true",
+        help="Do not use Kissat",
+    )
+    parser.add_argument(
+        "-M",
+        "--no-mergesat",
+        default=False,
+        action="store_true",
+        help="Do not use MergeSat",
+    )
 
 
 def parser_add_specsat_args(sub_parsers):
@@ -1616,14 +1637,17 @@ def run_assess_environment(args):
         assess_container_id = build_docker_container(dockerfile_dir=dockerfile_dir)
 
     solvers = dict()
-    solvers["cadical-watchsat-flto"] = cadical_watchsat_lto_solver(
-        docker_container_id=assess_container_id
-    )
-    solvers["kissat_bulky"] = kissat_bulky_solver(
-        docker_container_id=assess_container_id
-    )
-    solvers["mergesat"] = mergesat(docker_container_id=assess_container_id)
-    log.info("Work with solvers: %r", solvers)
+    if not args.get("no_cadical", False):
+        solvers["cadical-watchsat-flto"] = cadical_watchsat_lto_solver(
+            docker_container_id=assess_container_id
+        )
+    if not args.get("no_kissat", False):
+        solvers["kissat_bulky"] = kissat_bulky_solver(
+            docker_container_id=assess_container_id
+        )
+    if not args.get("no_mergesat", False):
+        solvers["mergesat"] = mergesat(docker_container_id=assess_container_id)
+        log.info("Work with solvers: %r", solvers)
 
     dir = tempfile.TemporaryDirectory()
 

--- a/SpecSAT.py
+++ b/SpecSAT.py
@@ -1720,6 +1720,7 @@ def run_assess_environment(args):
                             zipped_cnf,
                         )
                         return_code = 1
+                    log.info("Solver '%s' solver '%s' with data %r", solver_name, zipped_cnf, data)
                     assess_report["benchmarks"][benchmark][solver_name] = data
 
                 # Cleanup this iteration

--- a/assess_artifacts/Dockerfile
+++ b/assess_artifacts/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:22.04
+
+RUN apt-get update && \
+    apt-get -y upgrade && \
+    DEBIAN_FRONTEND=noninteractive apt-get -y install \
+        gcc \
+        git \
+        g++ \
+        make \
+        automake \
+        file


### PR DESCRIPTION
To implement related functionality, most of the code should be re-used. To be able to do this, the CLI should be capable of offering different commands.

This change implements the first 'specsat' command, as well as a stub for an 'assess' command.

Signed-off-by: Norbert Manthey <nmanthey@conp-solutions.com>